### PR TITLE
tag the published docker image also with the release number 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,8 @@ jobs:
           images: ghcr.io/${{ env.IMAGE }}
           tags: |
             type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha
 
       - name: Build and push main Docker image


### PR DESCRIPTION
tag the published docker image also with the release number extracted from git tag, making it easier for rollbacks targeting rather than using sha* versions.

Included a full version and a major.minor version, assuming patch level release won't break compatibility.